### PR TITLE
use new v2 endpoint

### DIFF
--- a/src/plugins/axios.js
+++ b/src/plugins/axios.js
@@ -4,9 +4,9 @@ export default ({ Vue, store }) => {
   // if (process.env.DEV) {
   //   axios.defaults.baseURL = 'http://localhost:8000/'
   // } else {
-  //   axios.defaults.baseURL = 'https://evnotify.de:8000/'
+  //   axios.defaults.baseURL = 'https://v2.evnotify.de:8000/'
   // }
-  axios.defaults.baseURL = 'https://evnotify.de:8000/'
+  axios.defaults.baseURL = 'https://v2.evnotify.de:8000/'
   axios.interceptors.request.use(config => {
     config.params = config.params || {}
     let target = config.params


### PR DESCRIPTION
v2 now uses a new server and (temporary) has a new URL. This may change in future. I have changed it to the new, current RESTURL.